### PR TITLE
ci: add org reusable security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,21 @@
+# Securite du depot via le reusable workflow org (flexwiz/.github).
+# gitleaks (secrets) + Trivy (vuln/misconfig) + titre de PR Conventional Commits.
+# Source unique : modifier le workflow se fait dans flexwiz/.github.
+name: security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  security:
+    permissions:
+      contents: read
+      pull-requests: read
+    # Pinne au SHA (Renovate bumpe) ; commentaire = ref lisible.
+    uses: flexwiz/.github/.github/workflows/security.yml@1aa017f531e8e06233d70eb3a3fc6a29cde23096 # main
+    with:
+      trivy-severity: CRITICAL,HIGH


### PR DESCRIPTION
## Summary

Add the org reusable security workflow ([`flexwiz/.github`](https://github.com/flexwiz/.github)): gitleaks (secrets), Trivy fs (vuln/misconfig), and Conventional Commits PR-title lint. Pinned to SHA `1aa017f`. This repo had no security CI before.

## Type of change

- [x] CI / tooling

## Notes

- Org Actions access is enabled on `flexwiz/.github` so this private repo can call it.
- Renovate (github-actions manager) will propose SHA bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)